### PR TITLE
feat(types): add TypeScript declarations and validate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
         # https://github.com/cypress-io/github-action
         uses: cypress-io/github-action@v6
 
+      - name: Check type declarations 🔎
+        run: npm run typecheck
+
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "cypress": "^15.7.0",
         "prettier": "^3.7.3",
-        "semantic-release": "^25.0.2"
+        "semantic-release": "^25.0.2",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@actions/core": {
@@ -169,7 +170,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1950,7 +1950,6 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -3344,7 +3343,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5590,7 +5588,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6411,7 +6408,6 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -7303,7 +7299,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7427,6 +7422,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {
@@ -7863,7 +7872,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -9124,7 +9132,6 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -10097,8 +10104,7 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "marked-terminal": {
       "version": "7.3.0",
@@ -11578,8 +11584,7 @@
             "picomatch": {
               "version": "4.0.3",
               "bundled": true,
-              "dev": true,
-              "peer": true
+              "dev": true
             }
           }
         },
@@ -12174,7 +12179,6 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12786,8 +12790,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -12873,6 +12876,12 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Add timestamps to Cypress tests, error screenshots, and Command Log",
   "files": [
     "support.js",
-    "plugin.js"
+    "plugin.js",
+    "support.d.ts",
+    "plugin.d.ts"
   ],
   "scripts": {
     "test": "cypress run",
     "open": "cypress open",
+    "typecheck": "tsc -p tsconfig.types.json",
     "semantic-release": "semantic-release",
     "badges": "npx -p dependency-version-badge update-badge cypress"
   },
@@ -28,7 +31,8 @@
   "devDependencies": {
     "cypress": "^15.7.0",
     "prettier": "^3.7.3",
-    "semantic-release": "^25.0.2"
+    "semantic-release": "^25.0.2",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "format-duration": "^3.0.0"

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="cypress" />
+
+declare function registerCypressTimestamps(
+  on: Cypress.PluginEvents,
+  config?: Cypress.PluginConfigOptions
+): void
+
+export = registerCypressTimestamps

--- a/support.d.ts
+++ b/support.d.ts
@@ -1,0 +1,14 @@
+declare namespace registerCypressTimestamps {
+  interface Options {
+    terminal?: boolean
+    error?: boolean
+    commandLog?: boolean | 'all'
+    elapsed?: boolean
+  }
+}
+
+declare function registerCypressTimestamps(
+  options?: registerCypressTimestamps.Options
+): void
+
+export = registerCypressTimestamps

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": false
+  },
+  "files": [
+    "plugin.d.ts",
+    "support.d.ts"
+  ]
+}


### PR DESCRIPTION
This PR adds TypeScript support for the package’s public subpath entrypoints by introducing `plugin.d.ts` and `support.d.ts`. These declaration files provide typed signatures for the exported registration functions so TypeScript users importing `cypress-timestamps/plugin` and `cypress-timestamps/support` get proper editor hints and compile-time checks.

The package file was updated to include the new declaration files in the published package. A focused declaration check was also added with `tsconfig.types.json` and `npm run typecheck`, which validates the `.d.ts` files without introducing a full TypeScript build pipeline for runtime code. CI now runs this type declaration check before semantic release. 

There are no changes to the runtime behavior.

Closes #11